### PR TITLE
fix: Cannot preview doc when mouse pointer is on package

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -20,5 +20,4 @@
 // Thanks for cors authors! Below is the source code information:
 // 		Repo: github.com/gin-contrib/cors
 //		Forked Version: v1.3.1
-
 package cors


### PR DESCRIPTION
#### What type of PR is this?

fix: Cannot preview doc when mouse pointer is on package

#### What this PR does / why we need it (English/Chinese):

before: 
![bl8XMSr6HC](https://user-images.githubusercontent.com/70408571/180186796-a818c6ba-6ded-47e9-a890-b21347895886.jpg)

after:
![image](https://user-images.githubusercontent.com/70408571/180187389-7f081028-30be-4991-8e58-6ef613b42373.png)
